### PR TITLE
feat: add main bottom navigation

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -1,21 +1,11 @@
-import { StyleSheet, View } from "react-native";
-import { PaperProvider, Text } from "react-native-paper";
+import { PaperProvider } from "react-native-paper";
+
+import MainNavigation from "./src/navigation/MainNavigation/MainNavigation";
 
 export default function App() {
   return (
     <PaperProvider>
-      <View style={styles.container}>
-        <Text>Hello, World!</Text>
-      </View>
+      <MainNavigation />
     </PaperProvider>
   );
 }
-
-const styles = StyleSheet.create({
-  container: {
-    flex: 1,
-    backgroundColor: "#fff",
-    alignItems: "center",
-    justifyContent: "center",
-  },
-});

--- a/src/navigation/MainNavigation/MainNavigation.tsx
+++ b/src/navigation/MainNavigation/MainNavigation.tsx
@@ -1,0 +1,46 @@
+import { useState } from "react";
+import { BottomNavigation } from "react-native-paper";
+
+import Account from "../../screens/Account/Account";
+import Events from "../../screens/Events/Events";
+import Posts from "../../screens/Posts/Posts";
+
+const MainNavigation = () => {
+  const [index, setIndex] = useState(0);
+  const [routes] = useState([
+    {
+      key: "posts",
+      title: "Posts",
+      focusedIcon: "home",
+      unfocusedIcon: "home-outline",
+    },
+    {
+      key: "events",
+      title: "Events",
+      focusedIcon: "calendar-month",
+      unfocusedIcon: "calendar-month-outline",
+    },
+    {
+      key: "account",
+      title: "Account",
+      focusedIcon: "account-circle",
+      unfocusedIcon: "account-circle-outline",
+    },
+  ]);
+
+  const renderScene = BottomNavigation.SceneMap({
+    posts: Posts,
+    events: Events,
+    account: Account,
+  });
+
+  return (
+    <BottomNavigation
+      navigationState={{ index, routes }}
+      onIndexChange={setIndex}
+      renderScene={renderScene}
+    />
+  );
+};
+
+export default MainNavigation;

--- a/src/screens/Account/Account.tsx
+++ b/src/screens/Account/Account.tsx
@@ -1,0 +1,12 @@
+import { Text } from "react-native-paper";
+import { SafeAreaView } from "react-native-safe-area-context";
+
+const Account = () => {
+  return (
+    <SafeAreaView>
+      <Text>Account</Text>
+    </SafeAreaView>
+  );
+};
+
+export default Account;

--- a/src/screens/Events/Events.tsx
+++ b/src/screens/Events/Events.tsx
@@ -1,0 +1,12 @@
+import { Text } from "react-native-paper";
+import { SafeAreaView } from "react-native-safe-area-context";
+
+const Events = () => {
+  return (
+    <SafeAreaView>
+      <Text>Events</Text>
+    </SafeAreaView>
+  );
+};
+
+export default Events;

--- a/src/screens/Posts/Posts.tsx
+++ b/src/screens/Posts/Posts.tsx
@@ -1,0 +1,12 @@
+import { Text } from "react-native-paper";
+import { SafeAreaView } from "react-native-safe-area-context";
+
+const Posts = () => {
+  return (
+    <SafeAreaView>
+      <Text>Posts</Text>
+    </SafeAreaView>
+  );
+};
+
+export default Posts;


### PR DESCRIPTION
I added simple bottom navigation and dummy components for 3 main screens: posts, events and account.

Video preview of the change:

https://github.com/MiNISpaceMobile/minispace-mobile/assets/53649257/16abaa96-4293-40b3-80e5-fecab9692b99
